### PR TITLE
Add support for CONTEXT_SPECIFIC CHOICE (CHOICE with tag) difinitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,8 +78,9 @@ const encoders = {
 
 function fromTree(element, definition) {
   let match = null;
+  const isDefinitionUniversal = isNaN(definition.tag);
 
-  if (definition.type === 'CHOICE') {
+  if (definition.type === 'CHOICE' && isDefinitionUniversal) {
     let choices = definition.elements; // @todo rename to choices
     let choice = null;
 
@@ -95,7 +96,6 @@ function fromTree(element, definition) {
     return null;
   }
 
-  const isDefinitionUniversal = isNaN(definition.tag);
   const definitionTag = isDefinitionUniversal
     ? universalTagMap[definition.type]
     : definition.tag;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/atesgoral/node-asn1-mapper#readme",
   "devDependencies": {
-    "ava": "^0.22.0",
+    "ava": "1.0.0-beta.4",
     "coveralls": "^2.13.1",
     "nyc": "^11.1.0"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -398,6 +398,38 @@ test('fromTree: CHOICE where second choice matches', (t) => {
   t.deepEqual(asn1Mapper.fromTree(tree, definition), mapped);
 });
 
+test('fromTree: CHOICE where element is CLS_CONTEXT_SPECIFIC and first choice matches', (t) => {
+  const tree = {
+    cls: CLS_CONTEXT_SPECIFIC,
+    form: FORM_CONSTRUCTED,
+    tagCode: 3,
+    elements: [{
+      cls: CLS_CONTEXT_SPECIFIC,
+      form: FORM_PRIMITIVE,
+      tagCode: 0,
+      value: Buffer.from([])
+    }]
+  };
+  const definition = {
+    type: 'CHOICE',
+    tag: 3,
+    elements: [{
+      name: 'foo',
+      tag: 0,
+      type: 'NULL'
+    }, {
+      name: 'bar',
+      tag: 1,
+      type: 'OCTET STRING'
+    }]
+  };
+  const mapped = {
+    foo: true
+  };
+
+  t.deepEqual(asn1Mapper.fromTree(tree, definition), mapped);
+});
+
 test('fromTree: CHOICE where no choices match', (t) => {
   const tree = {
     cls: CLS_UNIVERSAL,


### PR DESCRIPTION
If a definition is CONTEXT_SPECIFIC CHOICE (CHOICE with tag), fromTree function is unable to parse and face an exception. 

You can check the case in the following code snippet:

```
const operation = require('map-modules/dist/MAP-MobileServiceOperations.EXP.min.json')['updateLocation'];

const log = require('../log');

function handleOperation(argumentBuffer) {
  const argumentTree = asn1Tree.decode(argumentBuffer);  

  log.debug('Handling operation', JSON.stringify(argumentTree));

  const argument = asn1Mapper.fromTree(argumentTree, operation.argument);

  log.debug('Matched arguments', JSON.stringify(argument));
}

handleOperation(Buffer.from('3080040804120206943399f28107915344442970f20407915344442970f3a680800205e0a38080000000850205e000008b000000', 'hex'));
```
I think when CHOICE element has a tag (CONTEXT_SPECIFIC), its well enough to only check if the tag and tagCode matches. I just altered the code accordingly and added a test routine for this case.